### PR TITLE
Reimplement dog mining cautious

### DIFF
--- a/src/main/java/sophisticated_wolves/entity/SophisticatedWolf.java
+++ b/src/main/java/sophisticated_wolves/entity/SophisticatedWolf.java
@@ -111,7 +111,7 @@ public class SophisticatedWolf extends AEntitySophisticatedWolf {
         this.goalSelector.addGoal(27, new AvoidFireGoal(this, 1, 1.4)); //new behavior
         this.goalSelector.addGoal(28, drowngGoal); //new behavior
         this.goalSelector.addGoal(29, new BreedGoal(this, 1));
-        this.goalSelector.addGoal(30, new WaterAvoidingRandomStrollGoal(this, 1));
+        this.goalSelector.addGoal(30, new SWRandomStrollGoal(this, 1));
         this.goalSelector.addGoal(31, new FeedFromBowlGoal(this)); //new behavior
         this.goalSelector.addGoal(32, new FeedGoal(this)); //new behavior
         this.goalSelector.addGoal(35, new SWBegGoal(this, 8)); //changed behavior

--- a/src/main/java/sophisticated_wolves/entity/ai/SWFollowOwnerGoal.java
+++ b/src/main/java/sophisticated_wolves/entity/ai/SWFollowOwnerGoal.java
@@ -54,7 +54,7 @@ public class SWFollowOwnerGoal extends FollowOwnerGoal {
     }
 
     /**
-     * Updates the task TODO : fix dog cannot teleport
+     * Updates the task
      */
     @Override
     public void tick() {

--- a/src/main/java/sophisticated_wolves/entity/ai/SWFollowOwnerGoal.java
+++ b/src/main/java/sophisticated_wolves/entity/ai/SWFollowOwnerGoal.java
@@ -54,7 +54,7 @@ public class SWFollowOwnerGoal extends FollowOwnerGoal {
     }
 
     /**
-     * Updates the task
+     * Updates the task TODO : fix dog cannot teleport
      */
     @Override
     public void tick() {

--- a/src/main/java/sophisticated_wolves/entity/ai/SWRandomStrollGoal.java
+++ b/src/main/java/sophisticated_wolves/entity/ai/SWRandomStrollGoal.java
@@ -1,13 +1,8 @@
 package sophisticated_wolves.entity.ai;
 
-import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.WaterAvoidingRandomStrollGoal;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DiggerItem;
-import net.minecraft.world.item.PickaxeItem;
-import net.minecraft.world.item.ShovelItem;
 import sophisticated_wolves.entity.SophisticatedWolf;
 import sophisticated_wolves.util.DogUtil;
 
@@ -28,7 +23,7 @@ public class SWRandomStrollGoal extends WaterAvoidingRandomStrollGoal {
         }
         return super.canUse();
     }
-    
+
     //  I can see people is going to need this cause i once got my TorchDog into lava
     //Because this reason here.., and it is also kinda annoying to see dogs going in 
     //front of owner when mining.
@@ -41,14 +36,12 @@ public class SWRandomStrollGoal extends WaterAvoidingRandomStrollGoal {
     @Override
     public void tick() {
         super.tick();
-        
-        
 
         if (this.dog.tickCount < this.tickCountStopMiningCautious) {
             if (this.pathObstructOwnerMining()) {
                 this.stop();
             }
-        } 
+        }
     }
 
     //TODO Mining genius : the dog will follow owner while putting torch down 
@@ -58,11 +51,12 @@ public class SWRandomStrollGoal extends WaterAvoidingRandomStrollGoal {
     //Check if owner is swinging with a digger item in hand.
     private boolean ownerMayBeMining() {
         var owner = this.dog.getOwner();
-        if (owner == null) return false;
-        return
-            owner.swinging 
-            && owner.getMainHandItem().getItem() instanceof DiggerItem;
-            
+        if (owner == null) {
+            return false;
+        } else {
+            return owner.swinging &&
+                    owner.getMainHandItem().getItem() instanceof DiggerItem;
+        }
     }
 
     /**
@@ -70,27 +64,22 @@ public class SWRandomStrollGoal extends WaterAvoidingRandomStrollGoal {
      * an obstructing path is defined in {@link DogUtil#posWillCollideWithOwnerMovingForward}
      */
     private boolean pathObstructOwnerMining() {
+        var navigation = this.dog.getNavigation();
+        var path = navigation.getPath();
+        if (path != null) {
+            //Iterate through the next 5 blocks of the path and check if obstruct owner.
+            int nodeIndex = path.getNextNodeIndex();
+            int endIndex = Mth.clamp(nodeIndex + 5, nodeIndex, path.getNodeCount() - 1);
+            for (int i = nodeIndex; i < endIndex; i++) {
+                boolean flag = DogUtil.posWillCollideWithOwnerMovingForward(dog, path.getNodePos(i));
 
-        var n = this.dog.getNavigation(); 
-        var p = n.getPath();
-        if (p == null) return false;
-        
-        //Iterate through the next 5 blocks of the path and check if obstruct owner.
-        int i0 = p.getNextNodeIndex();
-        int i_end = Mth.clamp(i0+5, i0, p.getNodeCount()-1);
-        for (int i = i0; i < i_end; ++i) {
-
-            boolean flag = 
-                DogUtil.posWillCollideWithOwnerMovingForward(dog, p.getNodePos(i));
-
-            if (flag) {
-                return true;
-            } 
-
+                if (flag) {
+                    return true;
+                }
+            }
         }
 
         return false;
     }
 
-    
 }

--- a/src/main/java/sophisticated_wolves/entity/ai/SWRandomStrollGoal.java
+++ b/src/main/java/sophisticated_wolves/entity/ai/SWRandomStrollGoal.java
@@ -1,0 +1,96 @@
+package sophisticated_wolves.entity.ai;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.goal.WaterAvoidingRandomStrollGoal;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.DiggerItem;
+import net.minecraft.world.item.PickaxeItem;
+import net.minecraft.world.item.ShovelItem;
+import sophisticated_wolves.entity.SophisticatedWolf;
+import sophisticated_wolves.util.DogUtil;
+
+public class SWRandomStrollGoal extends WaterAvoidingRandomStrollGoal {
+
+    private SophisticatedWolf dog;
+    private int tickCountStopMiningCautious;
+
+    public SWRandomStrollGoal(SophisticatedWolf dog, double speedModifier) {
+        super(dog, speedModifier);
+        this.dog = dog;
+    }
+
+    @Override
+    public boolean canUse() {
+        if (this.ownerMayBeMining()) {
+            this.tickCountStopMiningCautious = this.dog.tickCount + 600; // keep checking for 30 seconds
+        }
+        return super.canUse();
+    }
+    
+    //  I can see people is going to need this cause i once got my TorchDog into lava
+    //Because this reason here.., and it is also kinda annoying to see dogs going in 
+    //front of owner when mining.
+    //
+    //  If Owner Swing with a DiggerItem in hand, go into Mining Cautious Mode, 
+    //retains the mode for 30 seconds when the owner stops swining. 
+    //
+    //  In the mode, upon moving towards a random block (even when out of reach)
+    //the dog will actively checks the path if 
+    @Override
+    public void tick() {
+        super.tick();
+        
+        
+
+        if (this.dog.tickCount < this.tickCountStopMiningCautious) {
+            if (this.pathObstructOwnerMining()) {
+                this.stop();
+            }
+        } 
+    }
+
+    //TODO Mining genius : the dog will follow owner while putting torch down 
+    //Closely and also run with him
+    //And lead any other dogs which is close too .... 
+    //TODO CHANGE : make the logic make more sense and efficent
+    //Check if owner is swinging with a digger item in hand.
+    private boolean ownerMayBeMining() {
+        var owner = this.dog.getOwner();
+        if (owner == null) return false;
+        return
+            owner.swinging 
+            && owner.getMainHandItem().getItem() instanceof DiggerItem;
+            
+    }
+
+    /**
+     * Check if the forward nodes in dog's path is obstructing owner mining,
+     * an obstructing path is defined in {@link DogUtil#posWillCollideWithOwnerMovingForward}
+     */
+    private boolean pathObstructOwnerMining() {
+
+        var n = this.dog.getNavigation(); 
+        var p = n.getPath();
+        if (p == null) return false;
+        
+        //Iterate through the next 5 blocks of the path and check if obstruct owner.
+        int i0 = p.getNextNodeIndex();
+        int i_end = Mth.clamp(i0+5, i0, p.getNodeCount()-1);
+        for (int i = i0; i < i_end; ++i) {
+
+            boolean flag = 
+                DogUtil.posWillCollideWithOwnerMovingForward(dog, p.getNodePos(i));
+
+            if (flag) {
+                return true;
+            } 
+
+        }
+
+        return false;
+    }
+
+    
+}

--- a/src/main/java/sophisticated_wolves/util/DogUtil.java
+++ b/src/main/java/sophisticated_wolves/util/DogUtil.java
@@ -1,0 +1,259 @@
+package sophisticated_wolves.util;
+
+import java.util.ArrayList;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.pathfinder.BlockPathTypes;
+import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+import sophisticated_wolves.entity.SophisticatedWolf;
+
+/**
+ * This is from DoggyTalentsNext, but it is my code, so it is okay if i
+ * reuse it here.
+ * 
+ * Items to utilize when dealing with various doggy stuffs
+ * NOTE: Functions here will not check if the thing involved is null or not
+ * ex: dog.getOwner(), that must be already done outside of here.
+ * @author DashieDev
+ */
+public class DogUtil {
+
+
+    /**
+     * Dog teleport with considerations from owner and always success when there is available block :
+     * <p>1. Chose the best block according to {@link DogUtil#chooseSafePosNearOwner} .</p>
+     * <p>2. Set dog fall distance to 0</p>
+     * <p>3. Teleport</p>
+     * 
+     * @param dog The Dog who will teleport
+     * @param radius Radius of the area to search for block to teleport
+     * @return true if teleport is success.
+     */
+    public static boolean searchAndTeleportToOwner(SophisticatedWolf dog, int radius) {
+        var target = chooseSafePosNearOwner(dog, radius);
+        if (target == null) {
+            return false;
+        }
+        teleportInternal(dog, target);
+        
+        return true;
+    }
+
+
+    /**
+     * This function will search for all of the eligible position into a list,
+     * then pick a random item and return;
+     * 
+     * @param dog The Dog
+     * @param radius Radius of the area to search for best pos
+     * @return the best block or null if no block is found.
+     */
+    public static BlockPos chooseSafePosNearOwner(SophisticatedWolf dog, int radius) {
+
+        var owner_b0 = dog.getOwner().blockPosition();
+
+        // Get BlockPos Arround the owner
+        var blockposes = BlockPos.betweenClosed(
+                owner_b0.offset(-radius, -1, -radius),
+                owner_b0.offset(radius, 1, radius));
+
+        // Filter out the safe pos
+        var safeblockposes = new ArrayList<BlockPos>();
+        for (var i : blockposes) {
+
+            if (wantToTeleportToThePosition(dog, i)) {
+                safeblockposes.add(new BlockPos(i.getX(), i.getY(), i.getZ()));
+            }         
+
+        }
+
+        // If no safe pos then return null
+        if (safeblockposes.size() <= 0) {
+            return null;
+        }
+
+        //Pick a random block from the final list and teleport
+        BlockPos finaltp = safeblockposes.get(
+            dog.getRandom().nextInt(safeblockposes.size()));
+        return finaltp;
+    }
+
+
+    /**
+     * Dog will pick randomly 10 block around the owner per call to this function 
+     * and teleport to one of them if it is eligible. This is the default behaviour,
+     * and may require several calls to success even if there is a spot.
+     * 
+     * @param dog The Dog
+     * @param radius Radius of the area to guess
+     * @return true if success
+     */
+    public static boolean guessAndTryToTeleportToOwner(SophisticatedWolf dog, int radius) {
+        var owner_b0 = dog.getOwner().blockPosition();
+
+        for (int i = 0; i < 10; ++i) {
+            int randX = owner_b0.getX() + dog.getRandom().nextIntBetweenInclusive(-radius, radius);
+            int randY= owner_b0.getY() + dog.getRandom().nextIntBetweenInclusive(-1, 1);
+            int randZ = owner_b0.getZ() + dog.getRandom().nextIntBetweenInclusive(-radius, radius);
+            var b0 = new BlockPos(randX, randY, randZ);
+
+            if (wantToTeleportToThePosition(dog, b0)) {
+                teleportInternal(dog, b0);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    
+    /**
+     * this function returns whether the position is eligible for the dog or not
+     * a position is eligible if : 
+     * <p><b>1.</b> The position is not closer than 2 blocks from the owner</p>
+     * <p><b>2.</b> The block is safe for the dog to teleport, a safe block is defined by 
+     * the function {@link DogUtil#isTeleportSafeBlock}</p>
+     * <p><b>3.</b> If the owner is sprinting then the dog must not obstruct the owner's
+     * sprint path, check based on {@link DogUtil#posWillCollideWithOwnerMovingForward}</p>
+     * 
+     * @param dog The dog
+     * @param pos The position
+     */
+    public static boolean wantToTeleportToThePosition(SophisticatedWolf dog, BlockPos pos) {
+        var owner_b0 = dog.getOwner().blockPosition();
+        boolean flag = 
+                // Not too close to owner
+                !(
+                    Mth.abs(owner_b0.getX() - pos.getX()) < 2
+                    && Mth.abs(owner_b0.getZ() - pos.getZ()) < 2 
+                ) 
+
+                // safe?
+                && isTeleportSafeBlock(dog, pos, false) 
+
+                // Can see owner at that pos
+                // && hasLineOfSightToOwnerAtPos(dog, pos)
+
+                // if Owner is sprinting then don't obstruct the owner sprint path
+                && !(
+                    dog.getOwner().isSprinting()
+                    && posWillCollideWithOwnerMovingForward(dog, pos)
+                ); 
+        return flag;
+    }
+
+
+    /**
+     * this function will check if the position the dog is trying to teleport
+     * is not going to obstruct the owner when he is moving towards a direction by teleporting
+     * in front of the ray that the owner is moving towards.
+     * dog.getOwner() must not be null before the call or else this function will crash the game.
+     * 
+     * @param dog The dog who is teleporting
+     * @param pos The position to check
+     */
+    public static boolean posWillCollideWithOwnerMovingForward(SophisticatedWolf dog, BlockPos pos) {
+        final var DISTANCE_AWAY = 1.5;
+
+        var ownerPos = dog.getOwner().position();
+
+        //get owner position and target position
+        var ownerPos2d = new Vec3(ownerPos.x(), 0, ownerPos.z()); 
+        var targetPos2d = new Vec3(pos.getX() + 0.5, 0, pos.getZ() + 0.5);
+        
+        //get owner look vector
+        var a1 = dog.getOwner().getYHeadRot();
+        var dx1 = -Mth.sin(a1*Mth.DEG_TO_RAD);
+        var dz1 = Mth.cos(a1*Mth.DEG_TO_RAD);
+        var ownerLookUnitVector = new Vec3(dx1, 0, dz1);
+        
+        //Check according to the below function
+        var x = distanceFromPointToLineOfUnitVector2DSqr(targetPos2d, ownerPos2d, ownerLookUnitVector);
+
+        if (x < 0 || x > DISTANCE_AWAY) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Check if the dog can see the owner at that position
+     * 
+     * @param dog The Dog
+     * @param pos Block to consider
+     */
+    public static boolean hasLineOfSightToOwnerAtPos(SophisticatedWolf dog, BlockPos pos) {
+        var pos1 = new Vec3(pos.getX() + 0.5, pos.getY() + dog.getOwner().getEyeHeight(), pos.getZ() + 0.5);
+        var pos2 = new Vec3(dog.getOwner().getX(), 
+            dog.getOwner().getY() + dog.getOwner().getEyeHeight(), dog.getOwner().getZ());
+        if (pos1.distanceTo(pos2) > 128.0D) {
+            return false;
+        } else {
+            return dog.level.clip(new ClipContext(pos1, pos2, ClipContext.Block.COLLIDER, 
+                ClipContext.Fluid.NONE, dog)).getType() == HitResult.Type.MISS;
+        }
+    }
+
+
+    //TODO will check is Safe Block according to the IDogAlteration
+    public static boolean isTeleportSafeBlock(SophisticatedWolf dog, BlockPos pos, boolean teleportToLeaves) {
+        var pathnodetype = WalkNodeEvaluator.getBlockPathTypeStatic(dog.level, pos.mutable());
+        if (pathnodetype != BlockPathTypes.WALKABLE) {
+            return false;
+        } else {
+            var blockstate = dog.level.getBlockState(pos.below());
+            if (!teleportToLeaves && blockstate.getBlock() instanceof LeavesBlock) {
+                return false;
+            } else {
+                var blockpos = pos.subtract(dog.blockPosition());
+                return dog.level.noCollision(dog, dog.getBoundingBox().move(blockpos));
+            }
+        }
+    }
+
+
+    /**
+     * <p>Let the context be in a 2d Cartesian system</p>
+     * <p>Let A be a point</p>
+     * <p>Let B be another point</p>
+     * <p>Let v be a unit vector</p>
+     * <p>Let d be a line from B and v</p>
+     * <p>Let u be vector from B to A</p>
+     * If Angle(u, v) < 90 this function will return the squared distance between A and d
+     * else this function will return -1.
+     * 
+     * 
+     * @author DashieDev
+     * @param A 
+     * @param B
+     * @param v
+     * @return the distance squared, -1 if Angle(u, v) > 90 
+     */
+    public static double distanceFromPointToLineOfUnitVector2DSqr(Vec3 A, Vec3 B, Vec3 v) {
+        var u = A.add(B.scale(-1));
+        var dot_u_v = u.dot(v);
+        if (dot_u_v < 0) return -1;
+        var dis_sqr = u.lengthSqr() - (dot_u_v*dot_u_v);
+        return dis_sqr;
+    }
+
+
+    public static boolean isSafeBlock() {
+        return false;
+    }
+
+    private static void teleportInternal(SophisticatedWolf dog, BlockPos target) {
+        dog.fallDistance = 0; //TODO I am not sure if Sophisticated Wolves want this...
+        dog.moveTo(target.getX() + 0.5F, target.getY(), target.getZ() + 0.5F, dog.getYRot(), dog.getXRot());
+        dog.getNavigation().stop();
+    }
+
+
+}

--- a/src/main/java/sophisticated_wolves/util/DogUtil.java
+++ b/src/main/java/sophisticated_wolves/util/DogUtil.java
@@ -1,37 +1,36 @@
 package sophisticated_wolves.util;
 
-import java.util.ArrayList;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.LeavesBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import sophisticated_wolves.entity.SophisticatedWolf;
 
+import java.util.stream.StreamSupport;
+
 /**
  * This is from DoggyTalentsNext, but it is my code, so it is okay if i
  * reuse it here.
- * 
+ * <p>
  * Items to utilize when dealing with various doggy stuffs
  * NOTE: Functions here will not check if the thing involved is null or not
  * ex: dog.getOwner(), that must be already done outside of here.
+ *
  * @author DashieDev
  */
 public class DogUtil {
-
 
     /**
      * Dog teleport with considerations from owner and always success when there is available block :
      * <p>1. Chose the best block according to {@link DogUtil#chooseSafePosNearOwner} .</p>
      * <p>2. Set dog fall distance to 0</p>
      * <p>3. Teleport</p>
-     * 
-     * @param dog The Dog who will teleport
+     *
+     * @param dog    The Dog who will teleport
      * @param radius Radius of the area to search for block to teleport
      * @return true if teleport is success.
      */
@@ -41,70 +40,52 @@ public class DogUtil {
             return false;
         }
         teleportInternal(dog, target);
-        
+
         return true;
     }
-
 
     /**
      * This function will search for all of the eligible position into a list,
      * then pick a random item and return;
-     * 
-     * @param dog The Dog
+     *
+     * @param dog    The Dog
      * @param radius Radius of the area to search for best pos
      * @return the best block or null if no block is found.
      */
     public static BlockPos chooseSafePosNearOwner(SophisticatedWolf dog, int radius) {
+        var ownerPosition = dog.getOwner().blockPosition();
 
-        var owner_b0 = dog.getOwner().blockPosition();
+        // Get BlockPos Around the owner
+        var blockPoses = BlockPos.betweenClosed(
+                ownerPosition.offset(-radius, -1, -radius),
+                ownerPosition.offset(radius, 1, radius));
 
-        // Get BlockPos Arround the owner
-        var blockposes = BlockPos.betweenClosed(
-                owner_b0.offset(-radius, -1, -radius),
-                owner_b0.offset(radius, 1, radius));
-
-        // Filter out the safe pos
-        var safeblockposes = new ArrayList<BlockPos>();
-        for (var i : blockposes) {
-
-            if (wantToTeleportToThePosition(dog, i)) {
-                safeblockposes.add(new BlockPos(i.getX(), i.getY(), i.getZ()));
-            }         
-
-        }
-
-        // If no safe pos then return null
-        if (safeblockposes.size() <= 0) {
-            return null;
-        }
-
-        //Pick a random block from the final list and teleport
-        BlockPos finaltp = safeblockposes.get(
-            dog.getRandom().nextInt(safeblockposes.size()));
-        return finaltp;
+        return StreamSupport.stream(blockPoses.spliterator(), false)
+                .filter(blockPos -> wantToTeleportToThePosition(dog, blockPos))
+                .findAny()
+                .orElse(null);
     }
 
-
     /**
-     * Dog will pick randomly 10 block around the owner per call to this function 
+     * Dog will pick randomly 10 block around the owner per call to this function
      * and teleport to one of them if it is eligible. This is the default behaviour,
      * and may require several calls to success even if there is a spot.
-     * 
-     * @param dog The Dog
+     *
+     * @param dog    The Dog
      * @param radius Radius of the area to guess
      * @return true if success
      */
     public static boolean guessAndTryToTeleportToOwner(SophisticatedWolf dog, int radius) {
-        var owner_b0 = dog.getOwner().blockPosition();
+        var ownerPosition = dog.getOwner().blockPosition();
 
-        for (int i = 0; i < 10; ++i) {
-            int randX = owner_b0.getX() + dog.getRandom().nextIntBetweenInclusive(-radius, radius);
-            int randY= owner_b0.getY() + dog.getRandom().nextIntBetweenInclusive(-1, 1);
-            int randZ = owner_b0.getZ() + dog.getRandom().nextIntBetweenInclusive(-radius, radius);
-            var b0 = new BlockPos(randX, randY, randZ);
+        for (int i = 0; i < 10; i++) {
+            int randX = ownerPosition.getX() + dog.getRandom().nextIntBetweenInclusive(-radius, radius);
+            int randY = ownerPosition.getY() + dog.getRandom().nextIntBetweenInclusive(-1, 1);
+            int randZ = ownerPosition.getZ() + dog.getRandom().nextIntBetweenInclusive(-radius, radius);
+            var pos = new BlockPos(randX, randY, randZ);
 
-            if (wantToTeleportToThePosition(dog, b0)) {
-                teleportInternal(dog, b0);
+            if (wantToTeleportToThePosition(dog, pos)) {
+                teleportInternal(dog, pos);
                 return true;
             }
         }
@@ -112,49 +93,35 @@ public class DogUtil {
         return false;
     }
 
-    
     /**
      * this function returns whether the position is eligible for the dog or not
-     * a position is eligible if : 
+     * a position is eligible if :
      * <p><b>1.</b> The position is not closer than 2 blocks from the owner</p>
-     * <p><b>2.</b> The block is safe for the dog to teleport, a safe block is defined by 
+     * <p><b>2.</b> The block is safe for the dog to teleport, a safe block is defined by
      * the function {@link DogUtil#isTeleportSafeBlock}</p>
      * <p><b>3.</b> If the owner is sprinting then the dog must not obstruct the owner's
      * sprint path, check based on {@link DogUtil#posWillCollideWithOwnerMovingForward}</p>
-     * 
+     *
      * @param dog The dog
      * @param pos The position
      */
     public static boolean wantToTeleportToThePosition(SophisticatedWolf dog, BlockPos pos) {
-        var owner_b0 = dog.getOwner().blockPosition();
-        boolean flag = 
-                // Not too close to owner
-                !(
-                    Mth.abs(owner_b0.getX() - pos.getX()) < 2
-                    && Mth.abs(owner_b0.getZ() - pos.getZ()) < 2 
-                ) 
+        var ownerPosition = dog.getOwner().blockPosition();
 
-                // safe?
-                && isTeleportSafeBlock(dog, pos, false) 
-
-                // Can see owner at that pos
-                // && hasLineOfSightToOwnerAtPos(dog, pos)
-
+        // Not too close to owner
+        return !(Mth.abs(ownerPosition.getX() - pos.getX()) < 2 &&
+                Mth.abs(ownerPosition.getZ() - pos.getZ()) < 2) &&
+                isTeleportSafeBlock(dog, pos, false) &&
                 // if Owner is sprinting then don't obstruct the owner sprint path
-                && !(
-                    dog.getOwner().isSprinting()
-                    && posWillCollideWithOwnerMovingForward(dog, pos)
-                ); 
-        return flag;
+                !(dog.getOwner().isSprinting() && posWillCollideWithOwnerMovingForward(dog, pos));
     }
-
 
     /**
      * this function will check if the position the dog is trying to teleport
      * is not going to obstruct the owner when he is moving towards a direction by teleporting
      * in front of the ray that the owner is moving towards.
      * dog.getOwner() must not be null before the call or else this function will crash the game.
-     * 
+     *
      * @param dog The dog who is teleporting
      * @param pos The position to check
      */
@@ -164,15 +131,15 @@ public class DogUtil {
         var ownerPos = dog.getOwner().position();
 
         //get owner position and target position
-        var ownerPos2d = new Vec3(ownerPos.x(), 0, ownerPos.z()); 
+        var ownerPos2d = new Vec3(ownerPos.x(), 0, ownerPos.z());
         var targetPos2d = new Vec3(pos.getX() + 0.5, 0, pos.getZ() + 0.5);
-        
+
         //get owner look vector
         var a1 = dog.getOwner().getYHeadRot();
-        var dx1 = -Mth.sin(a1*Mth.DEG_TO_RAD);
-        var dz1 = Mth.cos(a1*Mth.DEG_TO_RAD);
+        var dx1 = -Mth.sin(a1 * Mth.DEG_TO_RAD);
+        var dz1 = Mth.cos(a1 * Mth.DEG_TO_RAD);
         var ownerLookUnitVector = new Vec3(dx1, 0, dz1);
-        
+
         //Check according to the below function
         var x = distanceFromPointToLineOfUnitVector2DSqr(targetPos2d, ownerPos2d, ownerLookUnitVector);
 
@@ -182,42 +149,43 @@ public class DogUtil {
         return true;
     }
 
-
     /**
      * Check if the dog can see the owner at that position
-     * 
+     *
      * @param dog The Dog
      * @param pos Block to consider
      */
     public static boolean hasLineOfSightToOwnerAtPos(SophisticatedWolf dog, BlockPos pos) {
-        var pos1 = new Vec3(pos.getX() + 0.5, pos.getY() + dog.getOwner().getEyeHeight(), pos.getZ() + 0.5);
-        var pos2 = new Vec3(dog.getOwner().getX(), 
-            dog.getOwner().getY() + dog.getOwner().getEyeHeight(), dog.getOwner().getZ());
-        if (pos1.distanceTo(pos2) > 128.0D) {
+        var pos1 = new Vec3(
+                pos.getX() + 0.5,
+                pos.getY() + dog.getOwner().getEyeHeight(),
+                pos.getZ() + 0.5);
+        var pos2 = new Vec3(
+                dog.getOwner().getX(),
+                dog.getOwner().getY() + dog.getOwner().getEyeHeight(),
+                dog.getOwner().getZ());
+        if (pos1.distanceTo(pos2) > 128) {
             return false;
         } else {
-            return dog.level.clip(new ClipContext(pos1, pos2, ClipContext.Block.COLLIDER, 
-                ClipContext.Fluid.NONE, dog)).getType() == HitResult.Type.MISS;
+            return dog.getLevel().clip(new ClipContext(pos1, pos2, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, dog))
+                    .getType() == HitResult.Type.MISS;
         }
     }
-
 
     //TODO will check is Safe Block according to the IDogAlteration
     public static boolean isTeleportSafeBlock(SophisticatedWolf dog, BlockPos pos, boolean teleportToLeaves) {
-        var pathnodetype = WalkNodeEvaluator.getBlockPathTypeStatic(dog.level, pos.mutable());
-        if (pathnodetype != BlockPathTypes.WALKABLE) {
+        var pathNodeType = WalkNodeEvaluator.getBlockPathTypeStatic(dog.level, pos.mutable());
+        if (pathNodeType != BlockPathTypes.WALKABLE) {
             return false;
         } else {
-            var blockstate = dog.level.getBlockState(pos.below());
-            if (!teleportToLeaves && blockstate.getBlock() instanceof LeavesBlock) {
+            if (!teleportToLeaves && dog.getLevel().getBlockState(pos.below()).getBlock() instanceof LeavesBlock) {
                 return false;
             } else {
-                var blockpos = pos.subtract(dog.blockPosition());
-                return dog.level.noCollision(dog, dog.getBoundingBox().move(blockpos));
+                var blockPos = pos.subtract(dog.blockPosition());
+                return dog.getLevel().noCollision(dog, dog.getBoundingBox().move(blockPos));
             }
         }
     }
-
 
     /**
      * <p>Let the context be in a 2d Cartesian system</p>
@@ -228,32 +196,26 @@ public class DogUtil {
      * <p>Let u be vector from B to A</p>
      * If Angle(u, v) < 90 this function will return the squared distance between A and d
      * else this function will return -1.
-     * 
-     * 
-     * @author DashieDev
-     * @param A 
+     *
+     * @param A
      * @param B
      * @param v
-     * @return the distance squared, -1 if Angle(u, v) > 90 
+     * @return the distance squared, -1 if Angle(u, v) > 90
+     * @author DashieDev
      */
     public static double distanceFromPointToLineOfUnitVector2DSqr(Vec3 A, Vec3 B, Vec3 v) {
         var u = A.add(B.scale(-1));
-        var dot_u_v = u.dot(v);
-        if (dot_u_v < 0) return -1;
-        var dis_sqr = u.lengthSqr() - (dot_u_v*dot_u_v);
-        return dis_sqr;
-    }
-
-
-    public static boolean isSafeBlock() {
-        return false;
+        var dotUV = u.dot(v);
+        if (dotUV < 0) {
+            return -1;
+        }
+        return u.lengthSqr() - (dotUV * dotUV);
     }
 
     private static void teleportInternal(SophisticatedWolf dog, BlockPos target) {
         dog.fallDistance = 0; //TODO I am not sure if Sophisticated Wolves want this...
-        dog.moveTo(target.getX() + 0.5F, target.getY(), target.getZ() + 0.5F, dog.getYRot(), dog.getXRot());
+        dog.moveTo(target.getX() + 0.5, target.getY(), target.getZ() + 0.5, dog.getYRot(), dog.getXRot());
         dog.getNavigation().stop();
     }
-
 
 }


### PR DESCRIPTION
The solution actually came from Doggy Talents Next, but that is part of my code, so it is safe to reuse here 😉
The previous solution: Having a high-priority goal to LOCK the movement when the player is swinging
My solution: The original problem actually mostly caused by the RandomStollGoal, as the dog randomly walk in front of owner mining, which is kinda annoying and had been proven fatal sometimes. My solution is to also check if the owner is swinging and put the dog in a Mining Cautious Mode. In this mode, the dog will constantly check his upcoming nodes when he is navigating randomly in the Goal if it is obstructing the owner. Even when the owner stops swinging, the dog will remain in the mode for 30 seconds, this allows the owner to break the mining and then do something else like placing torches...